### PR TITLE
Removing call to function that no longer exists

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -351,8 +351,6 @@ function M.setup_mappings()
     nmap gQ "jyiwmo:,$S/<C-r>=WordForGq()<CR>//gcie\|1,''-&&\|:norm `ozz<c-b><c-e><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left>
     xnoremap gq "jymo:,$s/<C-r>=WordForGq()<CR>//gcie\|1,''-&&\|:norm `ozz<c-b><c-e><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left>
     xnoremap gQ "jymo:,$S/<C-r>=WordForGq()<CR>//gcie\|1,''-&&\|:norm `ozz<c-b><c-e><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left><left>
-
-  nnoremap <silent><esc> :call HideTerminalWindowOrNoh()<CR>:noh<CR>
   ]])
 end
 


### PR DESCRIPTION
Pressing esc is calling function that was removed , removing the mapping. Can potentially change this to `CloseTerminal()` but I'm assuming Ctrl + k is encouraged